### PR TITLE
Bumped python versions and added publish/test to action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: build
         run: make docker-image
+
+      - name: run
+        run: make run-container

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,3 +12,10 @@ jobs:
 
       - name: run
         run: make run-container
+
+      - name: publish
+        env:
+          GITHUB_USER: ${{ github.repository_owner }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO_ORG: ${{ github.repository_owner }}
+        run: make publish

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ __pycache__
 .coverage
 *.egg-info
 schemas
+
+.idea/

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,15 @@
 #!/usr/bin/make -f
 
+REPO_ORG ?= yannh
+
 .PHONY: docker-image
 docker-image:
-	docker build -f Dockerfile -t yannh/openapi2jsonschema .
+	docker build -f Dockerfile -t $(REPO_ORG)/openapi2jsonschema .
 
 publish: docker-image
-	docker tag yannh/openapi2jsonschema docker.pkg.github.com/yannh/openapi2jsonschema/openapi2jsonschema:latest
-	docker push docker.pkg.github.com/yannh/openapi2jsonschema/openapi2jsonschema:latest
+	echo "$(GITHUB_TOKEN)" | docker login -u $(GITHUB_USER) --password-stdin ghcr.io
+	docker tag $(REPO_ORG)/openapi2jsonschema ghcr.io/$(REPO_ORG)/openapi2jsonschema:latest
+	docker push ghcr.io/$(REPO_ORG)/openapi2jsonschema:latest
 
 venv:
 	python3 -m venv venv/
@@ -26,4 +29,4 @@ run: pip-install
 
 .PHONY: run-container
 run-container: docker-image
-	docker run yannh/openapi2jsonschema:latest https://raw.githubusercontent.com/kubernetes/kubernetes/master/api/openapi-spec/swagger.json
+	docker run $(REPO_ORG)/openapi2jsonschema:latest https://raw.githubusercontent.com/kubernetes/kubernetes/master/api/openapi-spec/swagger.json

--- a/Makefile
+++ b/Makefile
@@ -23,3 +23,7 @@ pip-freeze:
 .PHONY: run
 run: pip-install
 	python openapi2jsonschema/command.py https://raw.githubusercontent.com/kubernetes/kubernetes/master/api/openapi-spec/swagger.json
+
+.PHONY: run-container
+run-container: docker-image
+	docker run yannh/openapi2jsonschema:latest https://raw.githubusercontent.com/kubernetes/kubernetes/master/api/openapi-spec/swagger.json

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-click==7.1.2
-jsonref==0.2
-PyYAML==5.4.1
+click==8.1.8
+jsonref==1.1.0
+PyYAML==6.0.2


### PR DESCRIPTION
I wanted a new rebuild of the image, but rebuilding was failing due to the python deps. Have tested it by [generating OCP schemas](https://github.com/garethahealy/openshift-json-schema/tree/main/v4.18.0)

- added publish to github action with repo owner as env
- Added run-container to action
- Bumped python versions 
- Bumped action checkout to v4 